### PR TITLE
Removed prompt symbol to allow easy cut n' paste of command blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This software configuration has only been tested on the NCI raijin supercomputer
 Start by downloading the experiment configurations and the source repositories:
 
 ```
-$ git clone --recursive https://github.com/CWSL/access-om.git
-$ cd access-om
+git clone --recursive https://github.com/CWSL/access-om.git
+cd access-om
 ```
 
 This should be downloaded to a place which has enough disk space for the model inputs and output.
@@ -29,7 +29,7 @@ This should be downloaded to a place which has enough disk space for the model i
 The next step is to download experiment input data.
 
 ```{bash}
-$ ./get_input_data.py
+./get_input_data.py
 ```
 
 ## Compile
@@ -39,51 +39,51 @@ Each model and the OASIS coupler need to be built individually.
 Start with OASIS because it is needed by the others:
 
 ```
-$ export ACCESS_OM_DIR=$(pwd)
-$ export OASIS_ROOT=$ACCESS_OM_DIR/src/oasis3-mct/
-$ cd $OASIS_ROOT
-$ make
+export ACCESS_OM_DIR=$(pwd)
+export OASIS_ROOT=$ACCESS_OM_DIR/src/oasis3-mct/
+cd $OASIS_ROOT
+make
 ```
 
 Output from the OASIS build can be found in:
 
 ```{bash}
-$ less $ACCESS_OM_DIR/src/oasis3-mct/util/make_dir/COMP.log
+less $ACCESS_OM_DIR/src/oasis3-mct/util/make_dir/COMP.log
 ```
 
 Now compile the ocean, ice and file-based atmosphere.
 
 For ocean:
 ```{bash}
-$ cd $ACCESS_OM_DIR/src/mom/exp
-$ ./MOM_compile.csh --type ACCESS-OM --platform nci
+cd $ACCESS_OM_DIR/src/mom/exp
+./MOM_compile.csh --type ACCESS-OM --platform nci
 ```
 
 For ice:
 ```{bash}
-$ cd $ACCESS_OM_DIR/src/cice4
-$ ./bld/build.sh nci access-om 1440x1080
+cd $ACCESS_OM_DIR/src/cice4
+./bld/build.sh nci access-om 1440x1080
 ```
 
 OR, for the 1 deg ocean, ice configuration:
 
 ```{bash}
-$ cd $ACCESS_OM_DIR/src/cice4
-$ ./bld/build.sh nci access-om 360x300
+cd $ACCESS_OM_DIR/src/cice4
+./bld/build.sh nci access-om 360x300
 ```
 
 For atm:
 ```{bash}
-$ cd $ACCESS_OM_DIR/src/matm
-$ ./build/build.sh nci
+cd $ACCESS_OM_DIR/src/matm
+./build/build.sh nci
 ```
 
 Check that the executables exist:
 
 ```{bash}
-$ ls $ACCESS_OM_DIR/src/mom/exec/nci/ACCESS-OM/fms_ACCESS-OM.x
-$ ls $ACCESS_OM_DIR/cice4/build_access-om_1440x1080_192p/cice_access-om_1440x1080_192p.exe
-$ ls $ACCESS_OM_DIR/src/matm/build_nt62/matm_nt62.exe
+ls $ACCESS_OM_DIR/src/mom/exec/nci/ACCESS-OM/fms_ACCESS-OM.x
+ls $ACCESS_OM_DIR/cice4/build_access-om_1440x1080_192p/cice_access-om_1440x1080_192p.exe
+ls $ACCESS_OM_DIR/src/matm/build_nt62/matm_nt62.exe
 ```
 
 ## Run
@@ -91,30 +91,30 @@ $ ls $ACCESS_OM_DIR/src/matm/build_nt62/matm_nt62.exe
 Run the first month of the 0.25 degree CORE2 NYF experiment experiment:
 
 ```{bash}
-$ qsub -I -P x77 -q normal -v DISPLAY=$DISPLAY,ACCESS_OM_DIR=$ACCESS_OM_DIR -l ncpus=1168,mem=2000Gb,walltime=4:00:00,jobfs=100GB
-$ cd $ACCESS_OM_DIR/025deg/
-$ ln -s ../input/025deg/INPUT ./
-$ cp ../input/025deg/*.nc ./
-$ module load openmpi/1.8.4
-$ mpirun --mca orte_base_help_aggregate 0 -np 960 $ACCESS_OM_DIR/src/mom/exec/nci/ACCESS-OM/fms_ACCESS-OM.x : -np 192 $ACCESS_OM_DIR/src/cice4/build_access-om_1440x1080_192p/cice_access-om_1440x1080_192p.exe : -np 1 $ACCESS_OM_DIR/src/matm/build_nt62/matm_nt62.exe
+qsub -I -P x77 -q normal -v DISPLAY=$DISPLAY,ACCESS_OM_DIR=$ACCESS_OM_DIR -l ncpus=1168,mem=2000Gb,walltime=4:00:00,jobfs=100GB
+cd $ACCESS_OM_DIR/025deg/
+ln -s ../input/025deg/INPUT ./
+cp ../input/025deg/*.nc ./
+module load openmpi/1.8.4
+mpirun --mca orte_base_help_aggregate 0 -np 960 $ACCESS_OM_DIR/src/mom/exec/nci/ACCESS-OM/fms_ACCESS-OM.x : -np 192 $ACCESS_OM_DIR/src/cice4/build_access-om_1440x1080_192p/cice_access-om_1440x1080_192p.exe : -np 1 $ACCESS_OM_DIR/src/matm/build_nt62/matm_nt62.exe
 ```
 
 If the run fails or you want to start from scratch for any reason:
 ```{bash}
-$ cd $ACCESS_OM_DIR/025deg/
-$ cp ../input/025deg/*.nc ./
-$ <mpirrun command as above>
+cd $ACCESS_OM_DIR/025deg/
+cp ../input/025deg/*.nc ./
+<mpirrun command as above>
 ```
 
 To run the 1 degree CORE2 NYF experiment experiment:
 
 ```{bash}
-$ qsub -I -P x77 -q normal -v DISPLAY=$DISPLAY,ACCESS_OM_DIR=$ACCESS_OM_DIR -l ncpus=128,mem=248Gb,walltime=4:00:00,jobfs=100GB
-$ cd $ACCESS_OM_DIR/1deg/
-$ ln -s ../input/1deg/INPUT ./
-$ cp ../input/1deg/*.nc ./
-$ module load openmpi/1.8.4
-$ mpirun --mca orte_base_help_aggregate 0 -np 120 $ACCESS_OM_DIR/src/mom/exec/nci/ACCESS-OM/fms_ACCESS-OM.x : -np 6 $ACCESS_OM_DIR/src/cice4/build_access-om_360x300_6p/cice_access-om_360x300_6p.exe : -np 1 $ACCESS_OM_DIR/src/matm/build_nt62/matm_nt62.exe
+qsub -I -P x77 -q normal -v DISPLAY=$DISPLAY,ACCESS_OM_DIR=$ACCESS_OM_DIR -l ncpus=128,mem=248Gb,walltime=4:00:00,jobfs=100GB
+cd $ACCESS_OM_DIR/1deg/
+ln -s ../input/1deg/INPUT ./
+cp ../input/1deg/*.nc ./
+module load openmpi/1.8.4
+mpirun --mca orte_base_help_aggregate 0 -np 120 $ACCESS_OM_DIR/src/mom/exec/nci/ACCESS-OM/fms_ACCESS-OM.x : -np 6 $ACCESS_OM_DIR/src/cice4/build_access-om_360x300_6p/cice_access-om_360x300_6p.exe : -np 1 $ACCESS_OM_DIR/src/matm/build_nt62/matm_nt62.exe
 ```
 
 ## Verify


### PR DESCRIPTION
When I was trying to follow the instructions the '$' prompt symbols made it impossible to cut and paste code blocks.