### PR TITLE
Submodule checkout using HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "src/cice4"]
 	path = src/cice4
-	url = git@github.com:OceansAus/cice4.git
+	url = https://github.com/OceansAus/cice4.git
 [submodule "src/mom"]
 	path = src/mom
-	url = git@github.com:BreakawayLabs/mom.git
+	url = https://github.com/BreakawayLabs/mom.git
 [submodule "src/oasis3-mct"]
 	path = src/oasis3-mct
-	url = git@github.com:OceansAus/oasis3-mct.git
+	url = https://github.com/OceansAus/oasis3-mct.git
 [submodule "src/matm"]
 	path = src/matm
-	url = git@github.com:OceansAus/matm.git
+	url = https://github.com/OceansAus/matm.git

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This software configuration has only been tested on the NCI raijin supercomputer
 Start by downloading the experiment configurations and the source repositories:
 
 ```
-git clone --recursive https://github.com/CWSL/access-om.git
+git clone --recursive https://github.com/OceansAus/access-om.git
 cd access-om
 ```
 


### PR DESCRIPTION
I've replaced the SSH (git@github.com) checkout protocol with HTTPS.

I was having problems anonymously cloning the original repositories under ssh, presumably something to do with keys and access-om.  Switching to HTTPS seems to have helped.

Also fixed a very minor typo in the README.